### PR TITLE
Add easy selection of all resources in a round

### DIFF
--- a/po/fi.po
+++ b/po/fi.po
@@ -287,6 +287,9 @@ msgstr "Tietosisällöt"
 msgid "Select"
 msgstr "Valitse"
 
+msgid "Pick all"
+msgstr "Poimi kaikki"
+
 msgid "Create new suggestion and add selected resources"
 msgstr "Luo uusi ehdotus ja lisää valitut tietosisällöt"
 

--- a/po/template.pot
+++ b/po/template.pot
@@ -4,6 +4,9 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
+msgid "Removed user"
+msgstr ""
+
 msgid "Commenting period"
 msgstr ""
 
@@ -29,9 +32,6 @@ msgid "Cancel"
 msgstr ""
 
 msgid "Save"
-msgstr ""
-
-msgid "Removed user"
 msgstr ""
 
 msgid "First name"
@@ -268,6 +268,9 @@ msgid "Please select tool to get container resources for commenting."
 msgstr ""
 
 msgid "Resources"
+msgstr ""
+
+msgid "Pick All"
 msgstr ""
 
 msgid "Select"

--- a/src/app/components/form/integration-resource-list-item-component.ts
+++ b/src/app/components/form/integration-resource-list-item-component.ts
@@ -9,7 +9,7 @@ import { BehaviorSubject, Subscription } from 'rxjs';
   styleUrls: ['./integration-resource-list-item.component.scss'],
   template: `
     <div id="{{resource.id + '_resource_link'}}"
-         class="resource-result" *ngIf="resource.expanded; else flattened" [class.last]="theLast">
+         class="resource-result" *ngIf="resource.expanded" [class.last]="theLast">
       <div class="scrollable-content">
         <app-status class="status" [status]="resource.status"></app-status>
         <span class="title" (click)="emitSelectResourceEvent(resource)">{{ resource.getDisplayName(languageService, true) }}</span>
@@ -28,10 +28,6 @@ import { BehaviorSubject, Subscription } from 'rxjs';
         </div>
       </div>
     </div>
-    <ng-template #flattened>
-      <div class="flattened">
-      </div>
-    </ng-template>
   `
 })
 export class IntegrationResourceListItemComponent implements OnInit, OnDestroy {

--- a/src/app/components/form/integration-resource-list-item.component.scss
+++ b/src/app/components/form/integration-resource-list-item.component.scss
@@ -65,10 +65,3 @@
     padding-bottom: 15px;
   }
 }
-
-div.flattened {
-  box-sizing: border-box;
-  height: 1px;
-  margin: 0 10px;
-  border-bottom: 1px solid $gray;
-}

--- a/src/app/components/form/integration-resource-virtual-scroller-component.ts
+++ b/src/app/components/form/integration-resource-virtual-scroller-component.ts
@@ -74,8 +74,8 @@ export class IntegrationResourceVirtualScrollerComponent {
         this.restricts);
 
       results.forEach(x => {
-        // hide from the list in case they are visible
-        this.virtualScroller.viewPortItems
+        // mark any item already downloaded as hidden (unexpanded)
+        this.buffer
           .filter(item => item.uri === x.uri)
           .forEach(item => {
             item.expanded = false

--- a/src/app/components/form/integration-resource-virtual-scroller-component.ts
+++ b/src/app/components/form/integration-resource-virtual-scroller-component.ts
@@ -36,6 +36,7 @@ export class IntegrationResourceVirtualScrollerComponent {
   @Input() search$ = new BehaviorSubject('');
   @Input() restricts: string[];
   @Input() selectedResources$: BehaviorSubject<IntegrationResource[]>;
+
   public buffer: IntegrationResource[] = [];
   public loading = false;
   private previousRequestGotZeroResults = false; // this variable is used to stop an eternal loop in case of 0 results (due to filtering)
@@ -50,6 +51,48 @@ export class IntegrationResourceVirtualScrollerComponent {
   constructor(public configurationService: ConfigurationService,
               public languageService: LanguageService,
               private dataService: DataService) {
+  }
+
+  // pick all search results as selections
+  // this works separately from the virtual scrolling by fetching
+  // (or often re-fetching) the data and adding all of them to the selections
+  public async pickAll() {
+
+    this.loading = true;
+    let count = 0;
+
+    while (true) {
+      // fetch one page
+      const results = await this.dataService.getResourcesPaged(
+        this.containerType,
+        this.containerUri,
+        this.language,
+        this.thePageSize,
+        count,
+        this.status$.value,
+        this.search$.value,
+        this.restricts);
+
+      results.forEach(x => {
+        // hide from the list in case they are visible
+        this.virtualScroller.viewPortItems
+          .filter(item => item.uri === x.uri)
+          .forEach(item => {
+            item.expanded = false
+          });
+
+        // add as selected resource
+        this.selectResourceEvent.emit(x);
+      });
+
+      count += results.length;
+
+      if (results.length !== this.thePageSize) {
+        break;
+      }
+    }
+    this.virtualScroller.invalidateAllCachedMeasurements();
+    this.loading = false;
   }
 
   public fetchMore(event: IPageInfo) {

--- a/src/app/components/form/search-linked-integration-resource-multi-modal.component.html
+++ b/src/app/components/form/search-linked-integration-resource-multi-modal.component.html
@@ -48,20 +48,44 @@
                            id="integration_status_filter_dropdown"
                            [filterSubject]="status$"
                            [options]="statusOptions"></app-filter-dropdown>
+
+      <div class="d-inline-block">
+        <div class="input-group input-group-lg pl-2">
+          <button
+                  id="pick_all_modal_button"
+                  type="button"
+                  class="btn btn-action"
+                  (click)="pickAll()">
+            <span translate>Pick all</span>
+          </button>
+        </div>
+      </div>
     </div>
 
     <div class="modal-section-flexible content-box">
-      <app-integration-resource-virtual-scroller *ngIf="virtualScrollerInstanceToggle" [containerUri]="containerUri"
-                                                 [containerType]="containerType" [language]="languageService.language"
-                                                 [items]="searchResults$" [status$]="status$" [search$]="search$" [restricts]="restricts"
-                                                 [selectedResources$]="selectedResources$"
-                                                 (selectResourceEvent)="selectResource($event)">
+      <app-integration-resource-virtual-scroller
+        *ngIf="virtualScrollerInstanceToggle"
+        [containerUri]="containerUri"
+        [containerType]="containerType"
+        [language]="languageService.language"
+        [items]="searchResults$"
+        [status$]="status$"
+        [search$]="search$"
+        [restricts]="restricts"
+        [selectedResources$]="selectedResources$"
+        (selectResourceEvent)="selectResource($event)">
       </app-integration-resource-virtual-scroller>
-      <app-integration-resource-virtual-scroller *ngIf="!virtualScrollerInstanceToggle" [containerUri]="containerUri"
-                                                 [containerType]="containerType" [language]="languageService.language"
-                                                 [items]="searchResults$" [status$]="status$" [search$]="search$" [restricts]="restricts"
-                                                 [selectedResources$]="selectedResources$"
-                                                 (selectResourceEvent)="selectResource($event)">
+      <app-integration-resource-virtual-scroller
+        *ngIf="!virtualScrollerInstanceToggle"
+        [containerUri]="containerUri"
+        [containerType]="containerType"
+        [language]="languageService.language"
+        [items]="searchResults$"
+        [status$]="status$"
+        [search$]="search$"
+        [restricts]="restricts"
+        [selectedResources$]="selectedResources$"
+        (selectResourceEvent)="selectResource($event)">
       </app-integration-resource-virtual-scroller>
     </div>
   </div>

--- a/src/app/components/form/search-linked-integration-resource-multi-modal.component.ts
+++ b/src/app/components/form/search-linked-integration-resource-multi-modal.component.ts
@@ -11,6 +11,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { allStatuses, Status } from 'yti-common-ui/entities/status';
 import { IntegrationResourceType } from '../../services/api-schema';
 import { ConfigurationService } from '../../services/configuration.service';
+import { IntegrationResourceVirtualScrollerComponent } from './integration-resource-virtual-scroller-component';
 
 @Component({
   selector: 'app-search-linked-source-multi-modal',
@@ -20,6 +21,10 @@ import { ConfigurationService } from '../../services/configuration.service';
 export class SearchLinkedIntegrationResourceMultiModalComponent implements AfterViewInit, OnInit {
 
   @ViewChild('searchInput') searchInput: ElementRef;
+
+  // for accessing pickAll() of the child component
+  @ViewChild(IntegrationResourceVirtualScrollerComponent)
+  private virtualScrollerComponent: IntegrationResourceVirtualScrollerComponent;
 
   @Input() restricts: string[];
   @Input() useUILanguage: boolean;
@@ -115,6 +120,11 @@ export class SearchLinkedIntegrationResourceMultiModalComponent implements After
 
   select() {
     this.modal.close(this.selectedResources);
+  }
+
+  // pick all search results as selections
+  pickAll() {
+    this.virtualScrollerComponent.pickAll();
   }
 
   ngAfterViewInit() {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/25614946/112633113-9b08dd80-8e41-11eb-862e-484712481db4.png)

This is implemented so that the "Pick all" button will (re-)download all search results from the backend, and pick each result as a selection - just like if the user had clicked them on the list.

The full re-download is done because the UI uses virtual scrolling, meaning not all results may have been loaded yet. It would be possible to optimize the implementation so only missing results are downloaded, but for simplicity and robustness I've kept it as it is.

The visible list is updated to hide the picked results, just like they normally would.

Since this feature only picks the results as selections, user still has the option of un-selecting individual items, or cancelling the entire operation.
